### PR TITLE
Rename OSQP solver class from ProxqpSolver to OsqpSolver

### DIFF
--- a/plugins/osqp/QpSolversEigenOsqp.cpp
+++ b/plugins/osqp/QpSolversEigenOsqp.cpp
@@ -11,11 +11,7 @@
 namespace QpSolversEigen
 {
 
-/**
- * ProxqpSolver class is a class that implements the SolverInterface but does nothing.
- *
- */
-class ProxqpSolver final: public SolverInterface
+class OsqpSolver final: public SolverInterface
 {
 private:
     // OSQP solver
@@ -36,7 +32,7 @@ private:
     Eigen::VectorXd upperBoundBufferWithOsqpEigenInfty;
 
 public:
-    virtual ~ProxqpSolver() = default;
+    virtual ~OsqpSolver() = default;
 
     std::string getSolverName() const override;
     bool initSolver() override;
@@ -80,9 +76,9 @@ public:
 
 // The first argument needs to be coherent with the scheme used in
 // getShlibppFactoryNameFromSolverName, i.e. qpsolvers_eigen_<solverName>
-SHLIBPP_DEFINE_SHARED_SUBCLASS(qpsolvers_eigen_osqp, QpSolversEigen::ProxqpSolver, QpSolversEigen::SolverInterface);
+SHLIBPP_DEFINE_SHARED_SUBCLASS(qpsolvers_eigen_osqp, QpSolversEigen::OsqpSolver, QpSolversEigen::SolverInterface);
 
-QpSolversEigen::ErrorExitFlag ProxqpSolver::convertErrorExitFlag(const OsqpEigen::ErrorExitFlag errorExitFlag) const
+QpSolversEigen::ErrorExitFlag OsqpSolver::convertErrorExitFlag(const OsqpEigen::ErrorExitFlag errorExitFlag) const
 {
     switch (errorExitFlag)
     {
@@ -107,7 +103,7 @@ QpSolversEigen::ErrorExitFlag ProxqpSolver::convertErrorExitFlag(const OsqpEigen
     }
 }
 
-QpSolversEigen::Status ProxqpSolver::convertStatus(const OsqpEigen::Status status) const
+QpSolversEigen::Status OsqpSolver::convertStatus(const OsqpEigen::Status status) const
 {
     switch (status)
     {
@@ -138,7 +134,7 @@ QpSolversEigen::Status ProxqpSolver::convertStatus(const OsqpEigen::Status statu
     }
 }
 
-bool ProxqpSolver::convertQpSolversEigenInftyToOsqpEigenInfty(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& inputBound,
+bool OsqpSolver::convertQpSolversEigenInftyToOsqpEigenInfty(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& inputBound,
                                                             Eigen::VectorXd& outputBound)
 {
     outputBound = inputBound;
@@ -157,84 +153,84 @@ bool ProxqpSolver::convertQpSolversEigenInftyToOsqpEigenInfty(const Eigen::Ref<c
     return true;
 }
 
-std::string ProxqpSolver::getSolverName() const
+std::string OsqpSolver::getSolverName() const
 {
     return "osqp";
 }
 
-bool ProxqpSolver::initSolver()
+bool OsqpSolver::initSolver()
 {
     return osqpEigenSolver.initSolver();
 }
 
-bool ProxqpSolver::isInitialized()
+bool OsqpSolver::isInitialized()
 {
     return osqpEigenSolver.isInitialized();
 }
 
-void ProxqpSolver::clearSolver()
+void OsqpSolver::clearSolver()
 {
     return osqpEigenSolver.clearSolver();
 }
 
-bool ProxqpSolver::clearSolverVariables()
+bool OsqpSolver::clearSolverVariables()
 {
     return osqpEigenSolver.clearSolverVariables();
 }
 
-QpSolversEigen::ErrorExitFlag ProxqpSolver::solveProblem()
+QpSolversEigen::ErrorExitFlag OsqpSolver::solveProblem()
 {
     return this->convertErrorExitFlag(osqpEigenSolver.solveProblem());
 }
 
-QpSolversEigen::Status ProxqpSolver::getStatus() const
+QpSolversEigen::Status OsqpSolver::getStatus() const
 {
     return this->convertStatus(osqpEigenSolver.getStatus());
 }
 
-const double ProxqpSolver::getObjValue() const
+const double OsqpSolver::getObjValue() const
 {
     return osqpEigenSolver.getObjValue();
 }
 
-const Eigen::Matrix<double, Eigen::Dynamic, 1>& ProxqpSolver::getSolution()
+const Eigen::Matrix<double, Eigen::Dynamic, 1>& OsqpSolver::getSolution()
 {
     return osqpEigenSolver.getSolution();
 }
 
-const Eigen::Matrix<double, Eigen::Dynamic, 1>& ProxqpSolver::getDualSolution()
+const Eigen::Matrix<double, Eigen::Dynamic, 1>& OsqpSolver::getDualSolution()
 {
     return osqpEigenSolver.getDualSolution();
 }
 
-bool ProxqpSolver::updateHessianMatrix(const Eigen::SparseMatrix<double> &hessianMatrix)
+bool OsqpSolver::updateHessianMatrix(const Eigen::SparseMatrix<double> &hessianMatrix)
 {
     return osqpEigenSolver.updateHessianMatrix(hessianMatrix);
 }
 
-bool ProxqpSolver::updateLinearConstraintsMatrix(const Eigen::SparseMatrix<double> &linearConstraintsMatrix)
+bool OsqpSolver::updateLinearConstraintsMatrix(const Eigen::SparseMatrix<double> &linearConstraintsMatrix)
 {
     return osqpEigenSolver.updateLinearConstraintsMatrix(linearConstraintsMatrix);
 }
 
-bool ProxqpSolver::updateGradient(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& gradient)
+bool OsqpSolver::updateGradient(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& gradient)
 {
     return osqpEigenSolver.updateGradient(gradient);
 }
 
-bool ProxqpSolver::updateLowerBound(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& lowerBound)
+bool OsqpSolver::updateLowerBound(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& lowerBound)
 {
     bool ok = convertQpSolversEigenInftyToOsqpEigenInfty(lowerBound, lowerBoundBufferWithOsqpEigenInfty);
     return ok && osqpEigenSolver.updateLowerBound(lowerBoundBufferWithOsqpEigenInfty);
 }
 
-bool ProxqpSolver::updateUpperBound(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& upperBound)
+bool OsqpSolver::updateUpperBound(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& upperBound)
 {
     bool ok = convertQpSolversEigenInftyToOsqpEigenInfty(upperBound, upperBoundBufferWithOsqpEigenInfty);
     return ok && osqpEigenSolver.updateUpperBound(lowerBoundBufferWithOsqpEigenInfty);
 }
 
-bool ProxqpSolver::updateBounds(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& lowerBound,
+bool OsqpSolver::updateBounds(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& lowerBound,
              const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& upperBound)
 {
     bool ok = convertQpSolversEigenInftyToOsqpEigenInfty(lowerBound, lowerBoundBufferWithOsqpEigenInfty);
@@ -242,60 +238,60 @@ bool ProxqpSolver::updateBounds(const Eigen::Ref<const Eigen::Matrix<double, Eig
     return osqpEigenSolver.updateBounds(lowerBoundBufferWithOsqpEigenInfty, upperBoundBufferWithOsqpEigenInfty);
 }
 
-void ProxqpSolver::clearHessianMatrix()
+void OsqpSolver::clearHessianMatrix()
 {
     return osqpEigenSolver.data()->clearHessianMatrix();
 }
 
-void ProxqpSolver::clearLinearConstraintsMatrix()
+void OsqpSolver::clearLinearConstraintsMatrix()
 {
     return osqpEigenSolver.data()->clearLinearConstraintsMatrix();
 }
 
-void ProxqpSolver::setNumberOfVariables(int n)
+void OsqpSolver::setNumberOfVariables(int n)
 {
     return osqpEigenSolver.data()->setNumberOfVariables(n);
 }
 
-void ProxqpSolver::setNumberOfConstraints(int m)
+void OsqpSolver::setNumberOfConstraints(int m)
 {
     return osqpEigenSolver.data()->setNumberOfConstraints(m);
 }
 
-bool ProxqpSolver::setHessianMatrix(const Eigen::SparseMatrix<double>& hessianMatrix)
+bool OsqpSolver::setHessianMatrix(const Eigen::SparseMatrix<double>& hessianMatrix)
 {
     return osqpEigenSolver.data()->setHessianMatrix(hessianMatrix);
 }
 
-bool ProxqpSolver::setGradient(Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic, 1>> gradientVector)
+bool OsqpSolver::setGradient(Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic, 1>> gradientVector)
 {
     return  osqpEigenSolver.data()->setGradient(gradientVector);
 }
 
-Eigen::Matrix<double, Eigen::Dynamic, 1> ProxqpSolver::getGradient()
+Eigen::Matrix<double, Eigen::Dynamic, 1> OsqpSolver::getGradient()
 {
     return Eigen::Matrix<double, Eigen::Dynamic, 1>();
 }
 
 bool
-ProxqpSolver::setLinearConstraintsMatrix(const Eigen::SparseMatrix<double>& linearConstraintsMatrix)
+OsqpSolver::setLinearConstraintsMatrix(const Eigen::SparseMatrix<double>& linearConstraintsMatrix)
 {
     return osqpEigenSolver.data()->setLinearConstraintsMatrix(linearConstraintsMatrix);
 }
 
-bool ProxqpSolver::setLowerBound(Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic, 1>> lowerBoundVector)
+bool OsqpSolver::setLowerBound(Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic, 1>> lowerBoundVector)
 {
     bool ok = convertQpSolversEigenInftyToOsqpEigenInfty(lowerBoundVector, lowerBoundBufferWithOsqpEigenInfty);
     return osqpEigenSolver.data()->setLowerBound(lowerBoundBufferWithOsqpEigenInfty);
 }
 
-bool ProxqpSolver::setUpperBound(Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic, 1>> upperBoundVector)
+bool OsqpSolver::setUpperBound(Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic, 1>> upperBoundVector)
 {
     bool ok = convertQpSolversEigenInftyToOsqpEigenInfty(upperBoundVector, upperBoundBufferWithOsqpEigenInfty);
     return osqpEigenSolver.data()->setUpperBound(upperBoundVector);
 }
 
-bool ProxqpSolver::setBounds(Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic, 1>> lowerBound,
+bool OsqpSolver::setBounds(Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic, 1>> lowerBound,
                Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic, 1>> upperBound)
 {
     bool ok = convertQpSolversEigenInftyToOsqpEigenInfty(lowerBound, lowerBoundBufferWithOsqpEigenInfty);
@@ -303,7 +299,7 @@ bool ProxqpSolver::setBounds(Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic, 1>
     return osqpEigenSolver.data()->setBounds(lowerBoundBufferWithOsqpEigenInfty, upperBoundBufferWithOsqpEigenInfty);
 }
 
-bool ProxqpSolver::setBooleanParameter(const std::string& settingName, bool value)
+bool OsqpSolver::setBooleanParameter(const std::string& settingName, bool value)
 {
     // If you edit this method, remember to update
     // the documentation in the README of the osqp plugin
@@ -333,11 +329,11 @@ bool ProxqpSolver::setBooleanParameter(const std::string& settingName, bool valu
         return true;
     }
 
-    QpSolversEigen::debugStream() << "QpSolversEigen::ProxqpSolver::setBooleanParameter: unknown setting name: " << settingName << std::endl;
+    QpSolversEigen::debugStream() << "QpSolversEigen::OsqpSolver::setBooleanParameter: unknown setting name: " << settingName << std::endl;
     return false;
 }
 
-bool ProxqpSolver::setIntegerParameter(const std::string& settingName, int64_t value)
+bool OsqpSolver::setIntegerParameter(const std::string& settingName, int64_t value)
 {
     // If you edit this method, remember to update
     // the documentation in the README of the osqp plugin
@@ -367,11 +363,11 @@ bool ProxqpSolver::setIntegerParameter(const std::string& settingName, int64_t v
         return true;
     }
 
-    QpSolversEigen::debugStream() << "QpSolversEigen::ProxqpSolver::setIntegerParameter: unknown setting name: " << settingName << std::endl;
+    QpSolversEigen::debugStream() << "QpSolversEigen::OsqpSolver::setIntegerParameter: unknown setting name: " << settingName << std::endl;
     return false;
 }
 
-bool ProxqpSolver::setRealNumberParameter(const std::string& settingName, double value)
+bool OsqpSolver::setRealNumberParameter(const std::string& settingName, double value)
 {
     // If you edit this method, remember to update
     // the documentation in the README of the osqp plugin
@@ -417,13 +413,13 @@ bool ProxqpSolver::setRealNumberParameter(const std::string& settingName, double
         return true;
     }
 
-    QpSolversEigen::debugStream() << "QpSolversEigen::ProxqpSolver::setRealNumberParameter: unknown setting name: " << settingName << std::endl;
+    QpSolversEigen::debugStream() << "QpSolversEigen::OsqpSolver::setRealNumberParameter: unknown setting name: " << settingName << std::endl;
     return false;
 }
 
-SolverInterface* ProxqpSolver::allocateInstance() const
+SolverInterface* OsqpSolver::allocateInstance() const
 {
-    return new ProxqpSolver();
+    return new OsqpSolver();
 }
 
 }


### PR DESCRIPTION
Probably this was a leftover of when I added the proxqp solver. Everything continued to work fine as the factory symbols defined in `SHLIBPP_DEFINE_SHARED_SUBCLASS` were different between osqp and proxqp, but anyhow for clarity is better to have unique class names. : )

Reported by @GiulioRomualdi .