### PR TITLE
Fix setUpperBound and updateUpperBound in osqp plugin

### DIFF
--- a/plugins/osqp/QpSolversEigenOsqp.cpp
+++ b/plugins/osqp/QpSolversEigenOsqp.cpp
@@ -231,7 +231,7 @@ bool ProxqpSolver::updateLowerBound(const Eigen::Ref<const Eigen::Matrix<double,
 bool ProxqpSolver::updateUpperBound(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& upperBound)
 {
     bool ok = convertQpSolversEigenInftyToOsqpEigenInfty(upperBound, upperBoundBufferWithOsqpEigenInfty);
-    return ok && osqpEigenSolver.updateUpperBound(lowerBoundBufferWithOsqpEigenInfty);
+    return ok && osqpEigenSolver.updateUpperBound(upperBoundBufferWithOsqpEigenInfty);
 }
 
 bool ProxqpSolver::updateBounds(const Eigen::Ref<const Eigen::Matrix<double, Eigen::Dynamic, 1>>& lowerBound,
@@ -292,7 +292,7 @@ bool ProxqpSolver::setLowerBound(Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic
 bool ProxqpSolver::setUpperBound(Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic, 1>> upperBoundVector)
 {
     bool ok = convertQpSolversEigenInftyToOsqpEigenInfty(upperBoundVector, upperBoundBufferWithOsqpEigenInfty);
-    return osqpEigenSolver.data()->setUpperBound(upperBoundVector);
+    return osqpEigenSolver.data()->setUpperBound(upperBoundBufferWithOsqpEigenInfty);
 }
 
 bool ProxqpSolver::setBounds(Eigen::Ref<Eigen::Matrix<double, Eigen::Dynamic, 1>> lowerBound,


### PR DESCRIPTION
This PR fixes two bugs in setting upper bounds separately in the osqp plugin:
* In `updateUpperBound` we were passing the lower bound to osqp instead of the upper bound
* In `setUpperBound` we were passing the bounds without converting `QpSolversEigen::INFTY` (i.e. `std::numeric_limits<double>::infinity()`) to  OsqpEigen::INFTY (i.e. `1e20`) 

`setBounds` and `updateBounds` were not affected by the problems, and that is the reason tests were passing fine.