### PR TITLE
Add methods to get list of names of supported parameters for each solver

### DIFF
--- a/core/QpSolversEigen/NullSolver.cpp
+++ b/core/QpSolversEigen/NullSolver.cpp
@@ -162,6 +162,26 @@ bool NullSolver::setStringParameter(const std::string& parameterName, const std:
     return false;
 }
 
+bool NullSolver::getBooleanParametersNames(std::vector<std::string>& parametersNames) const
+{
+    return false;
+}
+
+bool NullSolver::getIntegerParametersNames(std::vector<std::string>& parametersNames) const
+{
+    return false;
+}
+
+bool NullSolver::getRealNumberParametersNames(std::vector<std::string>& parametersNames) const
+{
+    return false;
+}
+
+bool NullSolver::getStringParametersNames(std::vector<std::string>& parametersNames) const
+{
+    return false;
+}
+
 SolverInterface* NullSolver::allocateInstance() const
 {
     return new NullSolver();

--- a/core/QpSolversEigen/NullSolver.hpp
+++ b/core/QpSolversEigen/NullSolver.hpp
@@ -66,6 +66,12 @@ public:
     bool setIntegerParameter(const std::string& settingName, int64_t value) override;
     bool setRealNumberParameter(const std::string& settingName, double value) override;
     bool setStringParameter(const std::string& parameterName, const std::string& value) override;
+
+    bool getBooleanParametersNames(std::vector<std::string>& parametersNames) const override;
+    bool getIntegerParametersNames(std::vector<std::string>& parameterNames) const override;
+    bool getRealNumberParametersNames(std::vector<std::string>& parametersNames) const override;
+    bool getStringParametersNames(std::vector<std::string>& parametersNames) const override;
+
     SolverInterface* allocateInstance() const override;
 };
 

--- a/core/QpSolversEigen/Solver.cpp
+++ b/core/QpSolversEigen/Solver.cpp
@@ -289,6 +289,27 @@ bool Solver::setStringParameter(const std::string& parameterName, const std::str
     return m_pimpl->solver->setStringParameter(parameterName, value);
 }
 
+bool Solver::getBooleanParametersNames(std::vector<std::string>& parametersNames) const
+{
+    return m_pimpl->solver->getBooleanParametersNames(parametersNames);
+}
+
+bool Solver::getIntegerParametersNames(std::vector<std::string>& parameterNames) const
+{
+    return m_pimpl->solver->getIntegerParametersNames(parameterNames);
+}
+
+bool Solver::getRealNumberParametersNames(std::vector<std::string>& parametersNames) const
+{
+    return m_pimpl->solver->getRealNumberParametersNames(parametersNames);
+}
+
+bool Solver::getStringParametersNames(std::vector<std::string>& parametersNames) const
+{
+    return m_pimpl->solver->getStringParametersNames(parametersNames);
+}
+
+
 Solver* Solver::data()
 {
     return this;

--- a/core/QpSolversEigen/Solver.hpp
+++ b/core/QpSolversEigen/Solver.hpp
@@ -286,6 +286,35 @@ public:
     bool setStringParameter(const std::string& parameterName, const std::string& value);
 
     /**
+     * Get the names of all the boolean parameters supported by the solver.
+     * @param parametersNames the names of all the boolean parameters supported by the solver.
+     * @return true/false in case of success/failure.
+     */
+    bool getBooleanParametersNames(std::vector<std::string>& parametersNames) const;
+
+    /**
+     * Get the names of all the integer parameters supported by the solver.
+     * @param parametersNames the names of all the integer parameters supported by the solver.
+     * @return true/false in case of success/failure.
+     */
+    bool getIntegerParametersNames(std::vector<std::string>& parameterNames) const;
+
+    /**
+     * Get the names of all the real number parameters supported by the solver.
+     * @param parametersNames the names of all the real number parameters supported by the solver.
+     * @return true/false in case of success/failure.
+     */
+    bool getRealNumberParametersNames(std::vector<std::string>& parametersNames) const;
+
+    /**
+     * Get the names of all the string parameters supported by the solver.
+     * @param parametersNames the names of all the string parameters supported by the solver.
+     * @return true/false in case of success/failure.
+     */
+    bool getStringParametersNames(std::vector<std::string>& parametersNames) const ;
+
+
+    /**
      * Return a pointer to this class.
      *
      * This is just for backward compatibility with OsqpEigen::Solver::data() method,

--- a/core/QpSolversEigen/SolverInterface.hpp
+++ b/core/QpSolversEigen/SolverInterface.hpp
@@ -66,6 +66,11 @@ public:
     virtual bool setRealNumberParameter(const std::string& settingName, double value) = 0;
     virtual bool setStringParameter(const std::string& settingName, const std::string& value) = 0;
 
+    virtual bool getBooleanParametersNames(std::vector<std::string>& parametersNames) const = 0;
+    virtual bool getIntegerParametersNames(std::vector<std::string>& parameterNames) const = 0;
+    virtual bool getRealNumberParametersNames(std::vector<std::string>& parametersNames) const = 0;
+    virtual bool getStringParametersNames(std::vector<std::string>& parametersNames) const = 0;
+
     /**
      * Allocate a new instance of this class, and return a pointer to it.
      * The ownership of the pointer is transferred to the caller.

--- a/plugins/osqp/QpSolversEigenOsqp.cpp
+++ b/plugins/osqp/QpSolversEigenOsqp.cpp
@@ -72,6 +72,12 @@ public:
     bool setIntegerParameter(const std::string& settingName, int64_t value) override;
     bool setRealNumberParameter(const std::string& settingName, double value) override;
     bool setStringParameter(const std::string& parameterName, const std::string& value) override;
+
+    bool getBooleanParametersNames(std::vector<std::string>& parametersNames) const override;
+    bool getIntegerParametersNames(std::vector<std::string>& parameterNames) const override;
+    bool getRealNumberParametersNames(std::vector<std::string>& parametersNames) const override;
+    bool getStringParametersNames(std::vector<std::string>& parametersNames) const override;
+
     SolverInterface* allocateInstance() const override;
 };
 
@@ -424,6 +430,51 @@ bool OsqpSolver::setStringParameter(const std::string& parameterName, const std:
     return false;
 }
 
+bool OsqpSolver::getBooleanParametersNames(std::vector<std::string>& parametersNames) const
+{
+    parametersNames.resize(0);
+    parametersNames.push_back("polish");
+    parametersNames.push_back("verbose");
+    parametersNames.push_back("scaled_termination");
+    parametersNames.push_back("warm_start");
+    parametersNames.push_back("warm_starting");
+    parametersNames.push_back("adaptive_rho");
+    return true;
+}
+
+bool OsqpSolver::getIntegerParametersNames(std::vector<std::string>& parametersNames) const
+{
+    parametersNames.resize(0);
+    parametersNames.push_back("scaling");
+    parametersNames.push_back("adaptive_rho_interval");
+    parametersNames.push_back("max_iter");
+    parametersNames.push_back("polish_refine_iter");
+    parametersNames.push_back("linsys_solver");
+    parametersNames.push_back("check_termination");
+    return true;
+}
+
+bool OsqpSolver::getRealNumberParametersNames(std::vector<std::string>& parametersNames) const
+{
+    parametersNames.resize(0);
+    parametersNames.push_back("rho");
+    parametersNames.push_back("sigma");
+    parametersNames.push_back("adaptive_rho_tolerance");
+    parametersNames.push_back("adaptive_rho_fraction");
+    parametersNames.push_back("eps_abs");
+    parametersNames.push_back("eps_rel");
+    parametersNames.push_back("eps_prim_inf");
+    parametersNames.push_back("eps_dual_inf");
+    parametersNames.push_back("alpha");
+    parametersNames.push_back("delta");
+    return true;
+}
+
+bool OsqpSolver::getStringParametersNames(std::vector<std::string>& parametersNames) const
+{
+    parametersNames.resize(0);
+    return true;
+}
 
 SolverInterface* OsqpSolver::allocateInstance() const
 {

--- a/plugins/osqp/QpSolversEigenOsqp.cpp
+++ b/plugins/osqp/QpSolversEigenOsqp.cpp
@@ -432,7 +432,7 @@ bool OsqpSolver::setStringParameter(const std::string& parameterName, const std:
 
 bool OsqpSolver::getBooleanParametersNames(std::vector<std::string>& parametersNames) const
 {
-    parametersNames.resize(0);
+    parametersNames.clear();
     parametersNames.push_back("polish");
     parametersNames.push_back("verbose");
     parametersNames.push_back("scaled_termination");
@@ -444,7 +444,7 @@ bool OsqpSolver::getBooleanParametersNames(std::vector<std::string>& parametersN
 
 bool OsqpSolver::getIntegerParametersNames(std::vector<std::string>& parametersNames) const
 {
-    parametersNames.resize(0);
+    parametersNames.clear();
     parametersNames.push_back("scaling");
     parametersNames.push_back("adaptive_rho_interval");
     parametersNames.push_back("max_iter");
@@ -456,7 +456,7 @@ bool OsqpSolver::getIntegerParametersNames(std::vector<std::string>& parametersN
 
 bool OsqpSolver::getRealNumberParametersNames(std::vector<std::string>& parametersNames) const
 {
-    parametersNames.resize(0);
+    parametersNames.clear();
     parametersNames.push_back("rho");
     parametersNames.push_back("sigma");
     parametersNames.push_back("adaptive_rho_tolerance");
@@ -472,7 +472,7 @@ bool OsqpSolver::getRealNumberParametersNames(std::vector<std::string>& paramete
 
 bool OsqpSolver::getStringParametersNames(std::vector<std::string>& parametersNames) const
 {
-    parametersNames.resize(0);
+    parametersNames.clear();
     return true;
 }
 

--- a/plugins/proxqp/QpSolversEigenProxqp.cpp
+++ b/plugins/proxqp/QpSolversEigenProxqp.cpp
@@ -590,7 +590,7 @@ bool ProxqpSolver::setStringParameter(const std::string& parameterName, const st
 
 bool ProxqpSolver::getBooleanParametersNames(std::vector<std::string>& parametersNames) const
 {
-    parametersNames.resize(0);
+    parametersNames.clear();
     parametersNames.push_back("verbose");
     parametersNames.push_back("update_preconditioner");
     parametersNames.push_back("compute_preconditioner");
@@ -603,7 +603,7 @@ bool ProxqpSolver::getBooleanParametersNames(std::vector<std::string>& parameter
 
 bool ProxqpSolver::getIntegerParametersNames(std::vector<std::string>& parametersNames) const
 {
-    parametersNames.resize(0);
+    parametersNames.clear();
     parametersNames.push_back("max_iter");
     parametersNames.push_back("max_iter_in");
     parametersNames.push_back("safe_guard");
@@ -615,7 +615,7 @@ bool ProxqpSolver::getIntegerParametersNames(std::vector<std::string>& parameter
 
 bool ProxqpSolver::getRealNumberParametersNames(std::vector<std::string>& parametersNames) const
 {
-    parametersNames.resize(0);
+    parametersNames.clear();
     parametersNames.push_back("default_mu_eq");
     parametersNames.push_back("default_mu_in");
     parametersNames.push_back("alpha_bcl");
@@ -643,7 +643,7 @@ bool ProxqpSolver::getRealNumberParametersNames(std::vector<std::string>& parame
 
 bool ProxqpSolver::getStringParametersNames(std::vector<std::string>& parametersNames) const
 {
-    parametersNames.resize(0);
+    parametersNames.clear();
     parametersNames.push_back("initial_guess");
     return true;
 }

--- a/plugins/proxqp/QpSolversEigenProxqp.cpp
+++ b/plugins/proxqp/QpSolversEigenProxqp.cpp
@@ -103,6 +103,12 @@ public:
     bool setIntegerParameter(const std::string& settingName, int64_t value) override;
     bool setRealNumberParameter(const std::string& settingName, double value) override;
     bool setStringParameter(const std::string& parameterName, const std::string& value) override;
+
+    bool getBooleanParametersNames(std::vector<std::string>& parametersNames) const override;
+    bool getIntegerParametersNames(std::vector<std::string>& parametersNames) const override;
+    bool getRealNumberParametersNames(std::vector<std::string>& parametersNames) const override;
+    bool getStringParametersNames(std::vector<std::string>& parametersNames) const override;
+
     SolverInterface* allocateInstance() const override;
 };
 
@@ -582,6 +588,65 @@ bool ProxqpSolver::setStringParameter(const std::string& parameterName, const st
     return false;
 }
 
+bool ProxqpSolver::getBooleanParametersNames(std::vector<std::string>& parametersNames) const
+{
+    parametersNames.resize(0);
+    parametersNames.push_back("verbose");
+    parametersNames.push_back("update_preconditioner");
+    parametersNames.push_back("compute_preconditioner");
+    parametersNames.push_back("compute_timings");
+    parametersNames.push_back("check_duality_gap");
+    parametersNames.push_back("bcl_update");
+    parametersNames.push_back("primal_infeasibility_solving");
+    return true;
+}
+
+bool ProxqpSolver::getIntegerParametersNames(std::vector<std::string>& parametersNames) const
+{
+    parametersNames.resize(0);
+    parametersNames.push_back("max_iter");
+    parametersNames.push_back("max_iter_in");
+    parametersNames.push_back("safe_guard");
+    parametersNames.push_back("nb_iterative_refinement");
+    parametersNames.push_back("preconditioner_max_iter");
+    parametersNames.push_back("frequence_infeasibility_check");
+    return true;
+}
+
+bool ProxqpSolver::getRealNumberParametersNames(std::vector<std::string>& parametersNames) const
+{
+    parametersNames.resize(0);
+    parametersNames.push_back("default_mu_eq");
+    parametersNames.push_back("default_mu_in");
+    parametersNames.push_back("alpha_bcl");
+    parametersNames.push_back("beta_bcl");
+    parametersNames.push_back("refactor_dual_feasibility_threshold");
+    parametersNames.push_back("refactor_rho_threshold");
+    parametersNames.push_back("mu_min_in");
+    parametersNames.push_back("mu_max_eq_inv");
+    parametersNames.push_back("mu_max_in_inv");
+    parametersNames.push_back("mu_update_factor");
+    parametersNames.push_back("cold_reset_mu_eq");
+    parametersNames.push_back("cold_reset_mu_in");
+    parametersNames.push_back("cold_reset_mu_eq_inv");
+    parametersNames.push_back("cold_reset_mu_in_inv");
+    parametersNames.push_back("eps_abs");
+    parametersNames.push_back("eps_rel");
+    parametersNames.push_back("eps_refact");
+    parametersNames.push_back("eps_duality_gap_abs");
+    parametersNames.push_back("eps_duality_gap_rel");
+    parametersNames.push_back("preconditioner_accuracy");
+    parametersNames.push_back("alpha_gpdal");
+    parametersNames.push_back("default_H_eigenvalue_estimate");
+    return true;
+}
+
+bool ProxqpSolver::getStringParametersNames(std::vector<std::string>& parametersNames) const
+{
+    parametersNames.resize(0);
+    parametersNames.push_back("initial_guess");
+    return true;
+}
 
 SolverInterface* ProxqpSolver::allocateInstance() const
 {

--- a/tests/QPTest.cpp
+++ b/tests/QPTest.cpp
@@ -34,9 +34,22 @@ TEST_CASE("QPProblem - Unconstrained")
     REQUIRE(solver.instantiateSolver(solverName));
 
     REQUIRE(solver.setBooleanParameter("verbose", true));
+
+    // Verify that verbose parameters is reported as a supperted parameter
+    std::vector<std::string> parametersNames;
+    REQUIRE(solver.getBooleanParametersNames(parametersNames));
+    REQUIRE(std::find(parametersNames.begin(), parametersNames.end(), "verbose") != parametersNames.end());
+
+    // Check that a non-supported parameter is not reported
+    REQUIRE(std::find(parametersNames.begin(), parametersNames.end(), "this_is_not_a_supported_parameter") == parametersNames.end());
+
     if (solver.getSolverName() == "osqp")
     {
         REQUIRE(solver.setRealNumberParameter("alpha", 1.0));
+
+        REQUIRE(solver.getRealNumberParametersNames(parametersNames));
+        REQUIRE(std::find(parametersNames.begin(), parametersNames.end(), "alpha") != parametersNames.end());
+
     }
 
     solver.setNumberOfVariables(2);


### PR DESCRIPTION
This permits to get all the parameters supported by a solver, prerequisite for https://github.com/ami-iit/qpsolvers-eigen/issues/8 .