### PR TITLE
Fix pixi warnings and update setup-pixi version to 0.8.8

### DIFF
--- a/.github/workflows/test-pixi.yaml
+++ b/.github/workflows/test-pixi.yaml
@@ -45,7 +45,7 @@ jobs:
         sudo apt-get install libc6-dbg
 
     - name: Set up pixi
-      uses: prefix-dev/setup-pixi@v0.8.1
+      uses: prefix-dev/setup-pixi@v0.8.8
 
     - name: Print pixi info
       run: pixi info

--- a/.github/workflows/update-pixi-lockfile.yaml
+++ b/.github/workflows/update-pixi-lockfile.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up pixi
-        uses: prefix-dev/setup-pixi@v0.8.1
+        uses: prefix-dev/setup-pixi@v0.8.8
         with:
           run-install: false
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,10 +1,6 @@
 [project]
 name = "qpsolvers-eigen"
 authors = ["Silvio Traversaro <silvio@traversaro.it>", "Stefano Dafarra <stefano.dafarra@iit.it", "Giulio Romualdi <giulio.romualdi@iit.it>"]
-# As this version is currently ignored, we do not
-# waste effort in mantain it in synch with the value
-# specified in CMakeLists.txt
-version = "0.0.0"
 description = "C++ abstraction layers for Quadratic Programming Solvers."
 channels = ["conda-forge"]
 platforms = ["linux-64", "linux-aarch64", "win-64", "osx-64", "osx-arm64"]
@@ -39,9 +35,9 @@ configure = { cmd = [
     ".build",
 ]}
 
-build = { cmd = "cmake --build .build --config Release", depends_on = ["configure"] }
-test = { cmd = "ctest --test-dir .build --build-config Release", depends_on = ["build"] }
-install = { cmd = ["cmake", "--install", ".build", "--config", "Release"], depends_on = ["build"] }
+build = { cmd = "cmake --build .build --config Release", depends-on = ["configure"] }
+test = { cmd = "ctest --test-dir .build --build-config Release", depends-on = ["build"] }
+install = { cmd = ["cmake", "--install", ".build", "--config", "Release"], depends-on = ["build"] }
 uninstall = { cmd = ["cmake", "--build", ".build", "--target", "uninstall"]}
 
 


### PR DESCRIPTION
Fix warnings like:

~~~
  ⚠ The `depends_on` field is deprecated. Use `depends-on` instead.
    ╭─[D:\a\qpsolvers-eigen\qpsolvers-eigen\pixi.toml:44:76]
 43 │ test = { cmd = "ctest --test-dir .build --build-config Release", depends_on = ["build"] }
 44 │ install = { cmd = ["cmake", "--install", ".build", "--config", "Release"], depends_on = ["build"] }
    ·                                                                            ─────┬────
    ·                                                                                 ╰── replace this with 'depends-on'
 45 │ uninstall = { cmd = ["cmake", "--build", ".build", "--target", "uninstall"]}
    ╰────
~~~